### PR TITLE
Adds reusable triage workflow.

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,21 @@
+name: Triage
+
+on:
+  workflow_call:
+    inputs:
+      number_of_project:
+        required: true
+        type: string
+    secrets:
+      github-token:
+        required: true
+
+jobs:
+  add-ticket-to-project:
+    name: Add ticket to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.1.0
+        with:
+          project-url: https://github.com/orgs/maliput/projects/${{ inputs.number_of_project }}
+          github-token: ${{ secrets.github-token }}


### PR DESCRIPTION
Part of https://github.com/maliput/.github/issues/2

### Summary

- Creates a reusable workflow that adds tickets to a user-configurable project.
- It uses action/add-to-project action.
- The number of the project and the a token are required as inputs of the workflow.

### How to use it?

It can be used from any repo doing, for example.

```yml
name: Triage - Core Development

on:
  issues:
    types:
      - opened
  pull_request:
    types:
      - opened

jobs:
  add-ticket-to-project:
    uses: maliput/.github/.github/workflows/triage.yml@main
    with:
      number_of_project: "1"
    secrets:
      github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

```


